### PR TITLE
Add Vagrant Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "bento/centos-7.2"
+
+  config.vm.hostname = "devel"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", type: "dhcp"
+
+  # Tweak the VMs configuration.
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+  end
+end


### PR DESCRIPTION
[Vagrant](https://vagrantup.com) allows developers to build custom development environments in VMs. We've added a CentOS 7 VM to this project so we can have a reproducible development environment for that operating system.
