### PR TITLE
Add Ansible Provisioning to Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,4 +18,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.memory = 1024
   end
+
+  # Configure the VM using Ansible
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.playbook = "ansible/playbook.yml"
+    ansible.version = "2.1.2.0"
+  end
 end

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = False

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,8 @@
+---
+ - hosts: all
+   become: yes
+   tasks:
+       - name: install epel repository
+         yum: name=epel-release state=present
+       - name: install python3.4
+         yum: name=python34 state=present


### PR DESCRIPTION
Install the EPEL repository and Python 3.4, which is good enough for our system, as it will only be used to call the bootstrap.py script to initialize the Buildout project. From there on, Buildout will use its own local Python interpreter version.

[Ansible][ansible] is a configuration management tool for pushing out changes to an arbitrary set of hosts. We're using it here to install the aforementioned system software packages.
