### PR TITLE
Unpin Ansible Version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Configure the VM using Ansible
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "ansible/playbook.yml"
-    ansible.version = "2.1.2.0"
   end
 end


### PR DESCRIPTION
By default [Vagrant installs the latest Ansible version from EPEL](https://j.mp/2e8ZHlt), which should be more than sufficient.

This was causing an error because version 2.1.2.0 was not yet published to EPEL but was present in pip. The pip installation method is seemingly fraught with many other pitfalls, so we will avoid doing that.
