### PR TITLE
Add Scrapy to Project

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,3 +6,18 @@
          yum: name=epel-release state=present
        - name: install python3.4
          yum: name=python34 state=present
+       - name: install python dev packages
+         yum: name={{ item }} state=present
+         with_items:
+             # python development headers
+             - python34-devel
+             # openssl development headers
+             - openssl-devel
+             # foreign function interface development headers, required by some Python native extensions
+             - libffi-devel
+             # xml-related development headers
+             - libxslt-devel
+             - libxml2-devel
+             # build tools and compilers
+             - make
+             - gcc

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-parts = python ipython test
+parts = python ipython test scrapy
 develop = .
 eggs = tastyscrapy
 versions = versions
@@ -17,6 +17,12 @@ recipe = pbp.recipe.noserunner
 eggs = ${buildout:eggs}
     pbp.recipe.noserunner
 script = test
+
+[scrapy]
+recipe = zc.recipe.egg:scripts
+eggs = ${buildout:eggs}
+    scrapy
+scripts = scrapy
 
 [ipython]
 recipe = zc.recipe.egg:scripts

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     package_dir = { '': 'src' },
     install_requires = [
         'setuptools',
+        'scrapy >= 1.2.0, < 1.3.0',
     ],
 )


### PR DESCRIPTION
Here, we add in the actual [Scrapy](https://scrapy.org) library dependency in `setup.py`, the Scrapy script section in `buildout.cfg`, and the required system packages for building the various C Python extensions for the eggs that Scrapy requires.
