### PR TITLE
virtualenv Support with Buildout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,21 @@
+# python compiled files
 __pycache__
 *.pyc
 *.pyo
 
+# dotfiles
 /.installed.cfg
 /.vagrant
 
+# files
+/pip-selfcheck.json
+
+# directories
 /bin
 /develop-eggs
 /eggs
+/include
+/lib
+/lib64
 /parts
 /src/tastyscrapy.egg-info

--- a/README.md
+++ b/README.md
@@ -1,4 +1,70 @@
 # tastyscrapy
 
-A Scrapy project to scrape all public and private bookmarks in a Delicious
-account into a local SQLite database.
+A Scrapy project to scrape all public and private bookmarks in a Delicious account into a local SQLite database.
+
+## Development Workflow
+
+This project uses [Vagrant][vagrant], [Buildout][buildout], and [virtualenv][virtualenv] to provide an
+<em><strong>ULTRAGLORIOUS</em></strong> development lifecycle.
+
+To provide operating system isolation, Vagrant is used.
+
+### Vagrant
+
+The following commands bring up the Vagrant virtual machine
+and then shell into it:
+
+```
+vagrant up
+vagrant ssh
+```
+
+All commands from here are to be executed from within the Vagrant VM. Now change directories into `/vagrant`, where
+all project files live:
+
+```
+cd /vagrant
+```
+
+### virtualenv
+
+Next, to provide Python package isolation, we use [virtualenv][virtualenv], as documented
+[in the Buildout docs][buildout-virtualenv]:
+
+```
+virtualenv -p python3.4 .
+source bin/activate
+```
+
+The first line initializes the Python virtual environment with the system Python 3.4, and the second _activates_ it in
+the current shell.
+
+### Buildout
+
+We now execute Buildout's bootstrap script to set everything up for Buildout:
+
+```
+python3 bootstrap.py
+```
+
+Finally, now that everything has been set up properly, we can now execute Buildout to download and compile dependencies:
+
+```
+bin/buildout
+```
+
+The entire above workflow only needs to be executed once on project clone. After changing package versions,
+`bin/buildout` will need to be run again, but nothing else.
+
+After this is complete, there should be a number of scripts in the `bin` directory, including but not limited to:
+
+ - `bin/test`: Executes all unit tests.
+ - `bin/python`: Starts the Python interpreter.
+ - `bin/ipython`: Starts the IPython advanced Python interpreter for poking around.
+ - `bin/scrapy`: Invokes the Scrapy start script.
+
+
+ [vagrant]: https://vagrantup.com
+ [buildout]: https://pypi.python.org/pypi/zc.buildout/2.5.3
+ [buildout-virtualenv]: http://www.buildout.org/en/latest/install.html
+ [virtualenv]: https://virtualenv.pypa.io/en/stable/

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -4,20 +4,17 @@
    tasks:
        - name: install epel repository
          yum: name=epel-release state=present
-       - name: install python3.4
-         yum: name=python34 state=present
-       - name: install python dev packages
+       - name: install python dependencies
          yum: name={{ item }} state=present
          with_items:
-             # python development headers
+             - python-pip
+             - python34
              - python34-devel
-             # openssl development headers
              - openssl-devel
-             # foreign function interface development headers, required by some Python native extensions
              - libffi-devel
-             # xml-related development headers
-             - libxslt-devel
              - libxml2-devel
-             # build tools and compilers
+             - libxslt-devel
              - make
              - gcc
+       - name: install virtualenv
+         pip: name=virtualenv state=present

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,15 +1,10 @@
 [buildout]
-parts = python ipython test scrapy
+parts = ipython test scrapy
 develop = .
 eggs = tastyscrapy
 versions = versions
 
 [versions]
-
-[python]
-recipe = zc.recipe.egg
-interpreter = python
-eggs = ${buildout:eggs}
 
 [test]
 recipe = pbp.recipe.noserunner


### PR DESCRIPTION
Added virtualenv support to the project. I can't remember why I did this, but I did it for some important reason. virtualenv does _not_ solve for system level header files unfortunately, so that is most unfortunate.

Oh right, the reason I did this is so that in Travis, I can test against multiple system Pythons without screwing everything up. Buildout can probably do that on its own though. Whatever, I did this, here it is.
