### PR TITLE
Login to Delicious

### DIFF
--- a/scrapy.cfg
+++ b/scrapy.cfg
@@ -1,0 +1,12 @@
+# Automatically created by: scrapy startproject
+#
+# For more information about the [deploy] section see:
+# https://scrapyd.readthedocs.org/en/latest/deploy.html
+
+[settings]
+default = tastyscrapy.settings
+shell = bin/ipython
+
+[deploy]
+#url = http://localhost:6800/
+project = tastyscrapy

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(
     install_requires = [
         'setuptools',
         'scrapy >= 1.2.0, < 1.3.0',
+        'xjpath >= 0.1.5, < 0.2.0',
     ],
 )

--- a/src/tastyscrapy/exceptions.py
+++ b/src/tastyscrapy/exceptions.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+
+class LoginFailedException(Exception):
+    """
+    An exception thrown when unable to authenticate to Delicious.
+    """
+    pass

--- a/src/tastyscrapy/items.py
+++ b/src/tastyscrapy/items.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import scrapy
+
+
+class LoginSuccess(scrapy.Item):
+
+    created = scrapy.Field()

--- a/src/tastyscrapy/pipelines.py
+++ b/src/tastyscrapy/pipelines.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/src/tastyscrapy/settings.py
+++ b/src/tastyscrapy/settings.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from os import environ
+
+
+BOT_NAME = 'tastyscrapy'
+
+# list all spider modules to run
+SPIDER_MODULES = [
+    'tastyscrapy.spiders',
+]
+
+# create new spiders in this module
+NEWSPIDER_MODULE = 'tastyscrapy.spiders'
+
+# pull in the username and password from environment variables
+DELICIOUS_USERNAME = environ.get('DELICIOUS_USERNAME', '')
+DELICIOUS_PASSWORD = environ.get('DELICIOUS_PASSWORD', '')

--- a/src/tastyscrapy/spiders.py
+++ b/src/tastyscrapy/spiders.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+from datetime import datetime
+from tastyscrapy.exceptions import LoginFailedException
+from tastyscrapy.items import LoginSuccess
+
+import json
+import scrapy
+import xjpath
+
+
+class DeliciousSpider(scrapy.Spider):
+
+    name = 'delicious'
+
+    start_urls = ["https://del.icio.us/login"]
+
+    def parse(self, response):
+        """Default callback only used for initial login crawling."""
+        return [
+            scrapy.FormRequest.from_response(response,
+                formdata={'username': self.settings.get('DELICIOUS_USERNAME'),
+                          'password': self.settings.get('DELICIOUS_PASSWORD')},
+                callback=self.on_login_response)
+        ]
+
+    def on_login_response(self, response):
+        """
+        Callback method triggered on response to a login attempt.
+
+        Example response for a failed login attempt:
+        http://pastebin.com/c4Skavpa
+
+        Example response for a successful login attempt:
+        http://pastebin.com/Ds2Gqykr
+        """
+        if response.status != 200:
+            raise LoginFailedException("Received response {} when trying to log in.".format(response.status))
+
+        # create variable for storing the json payload
+        payload = None
+
+        try:
+            payload = json.loads(response.text)
+        except:
+            raise LoginFailedException("Unable to parse JSON response.")
+
+        if xjpath.path_lookup(payload, 'status') != ('success', True):
+            raise LoginFailedException("Unable to log in using provided credentials.")
+
+        # emit an item which shows that we logged in successfully for audit tracking
+        yield LoginSuccess(created=datetime.utcnow().isoformat())
+
+        redirect, is_success = xjpath.path_lookup(payload, 'redirect')
+
+        # start parsing items
+        yield scrapy.Request(redirect if is_success else "https://del.icio.us/{}".format(
+            self.settings.get('DELICIOUS_USERNAME')), callback=self.on_bookmark_response)
+
+    def on_bookmark_response(self, response):
+        """
+        Callback method triggered when login has succeeded or the next
+        bookmark page has been fetched.
+        """
+        pass


### PR DESCRIPTION
Added the necessary logic to have Scrapy use a POST request to login to Delicious, allowing us all the access.

Also, a number of other things:
- Create a `LoginSuccess` item whenever login has succeeded so we can audit and keep track of when we scraped.
- Use logic to determine whether we logged in successfully.
- Source username and password from the environment.
