### PR TITLE
SQLAlchemy Saving to SQLite :tada:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     install_requires = [
         'setuptools',
         'scrapy >= 1.2.0, < 1.3.0',
+        'sqlalchemy >= 1.1.2, < 1.2.0',
         'xjpath >= 0.1.5, < 0.2.0',
     ],
 )

--- a/src/tastyscrapy/model.py
+++ b/src/tastyscrapy/model.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from sqlalchemy import (
+    Boolean, Column, ForeignKey, Integer, String, Table, Text
+)
+from sqlalchemy.ext.declarative import declarative_base as Base
+from sqlalchemy.orm import relationship
+
+
+bookmark_tag_table = Table('bookmark_tag', Base.metadata,
+    Column(Integer, primary_key=True),
+    Column('bookmark_id', Integer, ForeignKey('bookmark.id')),
+    Column('tag_id', Integer, ForeignKey('tag.id')),
+)
+
+
+class Bookmark(Base):
+    __tablename__ = "bookmark"
+
+    id = Column(Integer, primary_key=True)
+    url = Column(String, index=True, unique=True)
+    title = Column(String)
+    comment = Column(Text)
+    private = Column(Boolean)
+    # many to many via bookmark_tag_table
+    tags = relationship("Tag", secondary=bookmark_tag_table,
+        back_populates="bookmarks")
+
+
+class Tag(Base):
+    __tablename__ = "tag"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, index=True, unique=True)
+    # many to many via bookmark_tag_table
+    bookmarks = relationship("Bookmark", secondary=bookmark_tag_table,
+        back_populates="tags")

--- a/src/tastyscrapy/model.py
+++ b/src/tastyscrapy/model.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import relationship
 
 
 bookmark_tag_table = Table('bookmark_tag', Base.metadata,
-    Column(Integer, primary_key=True),
+    Column('id', Integer, primary_key=True),
     Column('bookmark_id', Integer, ForeignKey('bookmark.id')),
     Column('tag_id', Integer, ForeignKey('tag.id')),
 )

--- a/src/tastyscrapy/pipelines.py
+++ b/src/tastyscrapy/pipelines.py
@@ -1,1 +1,25 @@
 #!/usr/bin/env python3
+
+from scrapy.exceptions import DropItem
+from tastyscrapy import model
+from tastyscrapy.items import Bookmark
+
+
+class DatabasePipeline(object):
+
+    def open_spider(self, spider):
+        """Callback on spider creation, used to setup SQLAlchemy."""
+
+    def process_item(self, item, spider):
+        """Callback on item returned from spider."""
+        if type(item) is Bookmark:
+            pass
+        else:
+            # not sure what this is, can't save it
+            spider.logger.warn("Unknown item of type {}", type(item))
+            raise DropItem
+
+    def save_bookmark(self, bookmark, spider):
+        """Saves or updates a bookmark to SQLAlchemy."""
+        # ie model.Bookmark(...).save_or_update()
+        # ie model.Tag(...).save_or_update()

--- a/src/tastyscrapy/settings.py
+++ b/src/tastyscrapy/settings.py
@@ -13,6 +13,11 @@ SPIDER_MODULES = [
 # create new spiders in this module
 NEWSPIDER_MODULE = 'tastyscrapy.spiders'
 
+# pipelines
+ITEM_PIPELINES = {
+    'tastyscrapy.pipelines.DatabasePipeline': 500,
+}
+
 # pull in the username and password from environment variables
 DELICIOUS_USERNAME = environ.get('DELICIOUS_USERNAME', '')
 DELICIOUS_PASSWORD = environ.get('DELICIOUS_PASSWORD', '')
@@ -24,3 +29,6 @@ def is_mark_private():
         in ['true', 'True', 'yes', 'on', True]
 
 DELICIOUS_MARK_PRIVATE = is_mark_private()
+
+# allow saving of database to custom output file
+DATABASE_FILE = environ.get('DATABASE_FILE', 'delicious.db')


### PR DESCRIPTION
Use SQLAlchemy as an ORM to map Python types to SQLite database tables, columns, etc.
